### PR TITLE
`ice outdated` fails when there is no dependencies

### DIFF
--- a/Tests/CLITests/OutdatedTests.swift
+++ b/Tests/CLITests/OutdatedTests.swift
@@ -27,4 +27,10 @@ class OutdatedTests: XCTestCase {
         """)
     }
     
+    func testOutdatedNoDependencies() {
+        let result = Runner.execute(args: ["outdated"], sandbox: .lib)
+        XCTAssertEqual(result.exitStatus, 0)
+        XCTAssertEqual(result.stderr, "")
+    }
+
 }


### PR DESCRIPTION
I added a test case for this problem