### PR TITLE
Add ice library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     name: "Ice",
     products: [
         .executable(name: "ice", targets: ["CLI"]),
+        .library(name: "Ice", targets: ["Core"]),
     ],
     dependencies: [
         .package(url: "https://github.com/jakeheis/FileKit", from: "4.1.0"),


### PR DESCRIPTION
This allows the Ice `Core` target to be used as a dependency, importable as `Ice`.
I'd like to use this for `Mint` https://github.com/yonaskolb/Mint/issues/17