### PR TITLE
Add code coverage option to xc command

### DIFF
--- a/Sources/IceCLI/Commands/Xc.swift
+++ b/Sources/IceCLI/Commands/Xc.swift
@@ -14,9 +14,10 @@ class XcCommand: IceObject, Command {
     let shortDescription = "Creates a new xcode project for the current package"
     
     let noOpen = Flag("-n", "--no-open", description: "Don't open the Xcode project after generating it")
+    let codeCoverage = Flag("-c", "--code-coverage", description: "Generate Xcode project with code coverage")
     
     func execute() throws {
-        try SPM().generateXcodeProject()
+        try SPM().generateXcodeProject(codeCoverage: codeCoverage.value)
         
         if noOpen.value || config.resolved.openAfterXc == false {
             return

--- a/Sources/IceKit/SPM.swift
+++ b/Sources/IceKit/SPM.swift
@@ -104,8 +104,13 @@ public class SPM {
         try runSwift(args: ["package", "update"], transformer: .resolve)
     }
 
-    public func generateXcodeProject() throws {
-        try runSwift(args: ["package", "generate-xcodeproj"], transformer: .xc)
+    public func generateXcodeProject(codeCoverage: Bool) throws {
+        if codeCoverage {
+            try runSwift(args: ["package", "generate-xcodeproj", "--enable-code-coverage"], transformer: .xc)
+        }
+        else {
+            try runSwift(args: ["package", "generate-xcodeproj"], transformer: .xc)
+        }
     }
     
     public func showBinPath(release: Bool = false) throws -> String {


### PR DESCRIPTION
Hi there! 

I've juste started using Ice and I really love it! 

One thing that I found missing though was the ability to generate code coverage when calling `ice xc`.

This pull request adds this option.

Best,  
-- Ladislas