### PR TITLE
Build and test using Xcode 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 language: generic
 sudo: required
 dist: trusty
-osx_image: xcode9.4
+osx_image: xcode10
 env:
 - SWIFT_VERSION=4.0
 - SWIFT_VERSION=4.1.2


### PR DESCRIPTION
Ice was updated to Swift 4.2, but the CI tests are still being run on Xcode 9.4. While this may not seem like a problem, running tests on macOS with Xcode 10 and Swift 4.2 gets the following error (taken from the Travis build):
```bash
$ swift test
/Users/travis/build/jakeheis/Ice: error: manifest parse error(s):
<unknown>:0: error: Swift does not support the SDK 'MacOSX10.13.sdk'
```

Using Xcode 10 gets rid of this error